### PR TITLE
エラーページ作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,31 @@
 class ApplicationController < ActionController::Base
+  unless Rails.env.development? || Rails.env.test?
+    rescue_from StandardError, with: :internal_server_error
+  end
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  def internal_server_error(error = nil)
+    log_error(error)
+    render template: "errors/internal_server_error", layout: "error", status: :internal_server_error
+  end
+
+  def not_found(error = nil)
+    log_error(error)
+    render template: "errors/not_found", layout: "error", status: :not_found
+  end
+
   private
 
     def after_sign_out_path_for(resource_or_scope)
       new_user_session_path
+    end
+
+    def log_error(error)
+      return unless error
+
+      Rails.logger.error <<~LOG
+        [#{error.class}] #{error.message}
+        #{error.backtrace&.join("\n")}
+      LOG
     end
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,10 @@
+<% provide(:title, "500") %>
+<div class="text-center mt-20">
+  <h1 class="text-8xl font-bold text-white mb-4">500</h1>
+  
+  <p class="text-lg text-white mb-2">Internal Server Error</p>
+  
+  <p class="text-lg text-white mb-8">サーバーで問題が発生しました。しばらくしてから再度お試しください。</p>
+  
+  <%= link_to "ホームに戻る", root_path, class: "inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition" %>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,7 @@
+<% provide(:title, "404") %>
+<div class="text-center mt-20">
+  <h1 class="text-8xl font-bold text-white mb-4">404</h1>
+  <p class="text-lg font-bold text-white mb-2">Not Found</p>
+  <p class="text-lg text-white mb-8">指定されたページは存在しません。URLを確認するか、以下から他のページへ移動してください。</p>
+  <%= link_to "ホームに戻る", root_path, class: "inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition" %>
+</div>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= yield(:title) %> | ItemMatch</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body class="bg-gradient-to-b from-blue-500 via-purple-500 to-white min-h-screen flex items-center justify-center">
+    <main class="w-full max-w-lg p-8">
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root "home#index"
+  match "*path", to: "application#not_found", via: :all
 end

--- a/spec/system/errors_spec.rb
+++ b/spec/system/errors_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Errors", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  describe "404 エラーページ" do
+    it "ページが見つからない時に404エラーページが表示されること" do
+      visit "/non_existent_path"
+
+      expect(page).to have_title("404 | ItemMatch")
+      expect(page).to have_content("404")
+      expect(page).to have_content("Not Found")
+      expect(page).to have_content("指定されたページは存在しません。URLを確認するか、以下から他のページへ移動してください。")
+    end
+  end
+end


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #28 

## 行ったこと

- 404ページ作成
- 500ページ作成
- ApplicationControllerで404と500エラーをキャッチしてページを作成する処理を作成
- 404エラーのシステムスペック作成

## 動作確認

http://localhost:3000/abc

## その他

500エラーのシステムスペックを実装していない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for application routes
	- Added custom error pages for 404 (Not Found) and 500 (Internal Server Error) scenarios
	- Implemented comprehensive error logging mechanism

- **Bug Fixes**
	- Improved handling of undefined routes and unexpected server errors

- **Documentation**
	- Created user-friendly error pages with multilingual support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->